### PR TITLE
Feature: Add Confirm Modal before deleting a book

### DIFF
--- a/App/src/App.tsx
+++ b/App/src/App.tsx
@@ -1,6 +1,7 @@
 // Import React hooks for state management and side effects
 import { useState, useEffect } from 'react';
 import { Plus, CreditCard as Edit2, Trash2, BookOpen } from 'lucide-react';
+import ConfirmModal from './Components/Common/ConfirmModal';
 
 // Define TypeScript interface for Book object
 interface Book {
@@ -30,6 +31,9 @@ function App() {
     year: new Date().getFullYear(),
     status: 'to-read' as 'read' | 'reading' | 'to-read'
   });
+
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [bookToDelete, setBookToDelete] = useState<string | null>(null);
 
   // Backend API URL
   const API_URL = 'http://localhost:5000/api';
@@ -112,25 +116,35 @@ function App() {
   };
 
   // Handle delete button click
-  const handleDelete = async (id: string) => {
-    // Confirm before deleting
-    if (!confirm('Are you sure you want to delete this book?')) {
-      return;
-    }
+      const handleDeleteClick = (id: string) => {
+    setBookToDelete(id);   // store the book ID
+    setIsModalOpen(true);  // open confirmation modal
+  };
+
+  const handleConfirmDelete = async () => {
+    if (!bookToDelete) return;
 
     try {
-      const response = await fetch(`${API_URL}/books/${id}`, {
-        method: 'DELETE'
+      const response = await fetch(`${API_URL}/books/${bookToDelete}`, {
+        method: "DELETE",
       });
 
       if (response.ok) {
-        alert('Book deleted successfully!');
+        alert("Book deleted successfully!");
         fetchBooks();
       }
     } catch (error) {
-      console.error('Error deleting book:', error);
-      alert('Failed to delete book');
+      console.error("Error deleting book:", error);
+      alert("Failed to delete book");
+    } finally {
+      setIsModalOpen(false);
+      setBookToDelete(null);
     }
+  };
+
+  const handleCancelDelete = () => {
+    setIsModalOpen(false);
+    setBookToDelete(null);
   };
 
   // Reset form to initial state
@@ -447,7 +461,7 @@ function App() {
                         </button>
                         {/* Delete Button */}
                         <button
-                          onClick={() => handleDelete(book._id)}
+                          onClick={() => handleDeleteClick(book._id)}
                           style={{
                             backgroundColor: '#ef4444',
                             color: 'white',
@@ -473,6 +487,13 @@ function App() {
           )}
         </div>
       </div>
+      <ConfirmModal
+          isOpen={isModalOpen}
+          title="Confirm Delete"
+          message="Are you sure you want to delete this book?"
+          onConfirm={handleConfirmDelete}
+          onCancel={handleCancelDelete}
+        />
     </div>
   );
 }

--- a/App/src/Components/Common/ConfirmModal.tsx
+++ b/App/src/Components/Common/ConfirmModal.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+
+interface ConfirmModalProps {
+  isOpen: boolean;
+  title?: string;
+  message: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+const ConfirmModal: React.FC<ConfirmModalProps> = ({
+  isOpen,
+  title = "Are you sure?",
+  message,
+  onConfirm,
+  onCancel,
+}) => {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white rounded-lg shadow-lg p-6 w-80">
+        <h2 className="text-xl font-bold mb-4">{title}</h2>
+        <p className="mb-6">{message}</p>
+        <div className="flex justify-end gap-3">
+          <button
+            onClick={onCancel}
+            className="px-4 py-2 rounded bg-gray-300 hover:bg-gray-400"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onConfirm}
+            className="px-4 py-2 rounded bg-red-600 text-white hover:bg-red-700"
+          >
+            Confirm
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ConfirmModal;


### PR DESCRIPTION
##Description:
This PR introduces a confirmation modal to prevent accidental deletion of books in the Book Tracker app. Currently, users can delete a book immediately by clicking the “Delete” button, which risks accidental data loss.

##Changes Made:
  -Added a reusable ConfirmModal.tsx component for delete confirmations.
  -Updated App.tsx to:
       -Use isModalOpen and bookToDelete state variables to control the modal.
       -Show the confirmation modal when the user clicks the delete button.
       -Only delete a book if the user confirms.
       -Reset modal state on cancel.
  -Preserves existing functionality for editing and adding books.
  -Designed modal to be reusable for future confirmation actions.

##Screenshot:
<img width="1919" height="865" alt="Screenshot 2025-10-12 130833" src="https://github.com/user-attachments/assets/37fc6079-9d59-494f-bcb8-916a0c15920c" />


##fixes issue: #6 